### PR TITLE
Fix issue that foldable device restart activity after expand

### DIFF
--- a/tedonactivityresult/src/main/AndroidManifest.xml
+++ b/tedonactivityresult/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <activity
         android:name=".ProxyActivity"
-        android:configChanges="mcc|mnc|locale|keyboard|keyboardHidden|screenLayout|fontScale|uiMode|orientation|screenSize|layoutDirection"
+        android:configChanges="mcc|mnc|locale|keyboard|keyboardHidden|screenLayout|fontScale|uiMode|orientation|screenSize|layoutDirection|smallestScreenSize"
         android:screenOrientation="unspecified"
         android:theme="@style/Theme.AppCompat.Light.Dialog" />
   </application>


### PR DESCRIPTION
## Issue re;
1. start any TargetActivity using TedActivityForResult
2. Expand or collapse foldable device
3. Finish TargetActivity
4. Restart TargetActivity 😱 

## Cause
- ProxyActivity start targetActivity called onCreate() when configuration changes

## Solution
- Add "smallestScreenSize" type to manifest

- ref: https://developer.android.com/guide/topics/large-screens/test-apps-on-foldables?hl=ko#configuration_changes
```
android:configChanges="orientation|screenLayout|screenSize|smallestScreenSize"
```